### PR TITLE
Allow to disable fill color

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,9 +19,14 @@
     <div class="controls">
       <label for="fontSize">Font Size (pt):</label>
       <input id="fontSize" type="number" min="1" step="1.0" value="20">
-      <label for="fillColor">Fill Color:</label>
-      <!-- eslint-disable-next-line @html-eslint/use-baseline -->
-      <input id="fillColor" type="color" value="#000000">
+      <div class="fill-color-group">
+        <label>
+          <input id="fillColorEnabled" type="checkbox" checked>
+          <span>Fill Color:</span>
+        </label>
+        <!-- eslint-disable-next-line @html-eslint/use-baseline -->
+        <input id="fillColor" type="color" value="#000000">
+      </div>
     </div>
     <textarea id="typstInput" placeholder="Enter Typst code... e.g. $ a^2 + b^2 = c^2 $"></textarea>
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -14,7 +14,7 @@ async function initialeUiState() {
 
   const savedFillColor = getStoredValue("typstFillColor");
   if (savedFillColor) {
-    setFillColor(savedFillColor);
+    setFillColor(savedFillColor === "disabled" ? null : savedFillColor);
   }
 }
 

--- a/web/src/powerpoint.js
+++ b/web/src/powerpoint.js
@@ -45,7 +45,7 @@ async function findTypstShape(selectedShapes, allSlides, context) {
  * @param {Object} shape - PowerPoint shape object
  * @param {string} payload - Encoded Typst source
  * @param {string} fontSize - Font size value
- * @param {string} fillColor - Fill color value
+ * @param {string|null} fillColor - Fill color value or null if disabled
  * @param {Object} position - Position with left and top properties
  * @param {Object} size - Size with width and height properties
  * @param {Object} context - PowerPoint context
@@ -54,7 +54,7 @@ async function tagShape(shape, payload, fontSize, fillColor, position, size, con
   shape.altTextDescription = payload;
   shape.name = "Typst Equation";
   shape.tags.add("TypstFontSize", fontSize.toString());
-  shape.tags.add("TypstFillColor", fillColor);
+  shape.tags.add("TypstFillColor", fillColor === null ? "disabled" : fillColor);
 
   if (size.height > 0 && size.width > 0) {
     shape.height = size.height;
@@ -286,7 +286,7 @@ export async function handleSelectionChange() {
           const storedFillColor = await readFillColorTag(typstShape, context);
 
           setFontSize(storedFontSize || "20");
-          setFillColor(storedFillColor || "#000000");
+          setFillColor((storedFillColor === "disabled" || !storedFillColor) ? null : storedFillColor);
           setTypstCode(decodedCode);
 
           debug("Loaded Typst payload from selection");

--- a/web/src/ui.js
+++ b/web/src/ui.js
@@ -36,20 +36,39 @@ export function setFontSize(fontSize) {
 
 /**
  * Gets the current fill color from the UI
- * @returns {string} Fill color value
+ * @returns {string|null} Fill color value or null if disabled
  */
 export function getFillColor() {
+  const enabled = document.getElementById("fillColorEnabled")?.checked;
+  if (!enabled) {
+    return null;
+  }
   return document.getElementById("fillColor").value || "#000000";
 }
 
 /**
  * Sets the fill color in the UI
- * @param {string} color - Fill color to set
+ * @param {string|null} color - Fill color to set, or null to disable
  */
 export function setFillColor(color) {
   const fillColorInput = document.getElementById("fillColor");
-  if (fillColorInput) {
-    fillColorInput.value = color;
+  const fillColorEnabled = document.getElementById("fillColorEnabled");
+
+  if (color === null) {
+    if (fillColorEnabled) {
+      fillColorEnabled.checked = false;
+    }
+    if (fillColorInput) {
+      fillColorInput.disabled = true;
+    }
+  } else {
+    if (fillColorEnabled) {
+      fillColorEnabled.checked = true;
+    }
+    if (fillColorInput) {
+      fillColorInput.value = color;
+      fillColorInput.disabled = false;
+    }
   }
 }
 
@@ -123,10 +142,12 @@ export async function updatePreview() {
         svgElement.style.height = "auto";
         svgElement.style.maxHeight = "150px";
 
-        // Apply white or black fill for preview based on dark mode
-        const isDarkMode = !document.documentElement.classList.contains("light-mode");
-        const previewFill = isDarkMode ? "#ffffff" : "#000000";
-        applyFillToSvgElement(svgElement, previewFill);
+        const fillColor = getFillColor();
+        if (fillColor !== null) {
+          const isDarkMode = !document.documentElement.classList.contains("light-mode");
+          const previewFill = isDarkMode ? "#ffffff" : "#000000";
+          applyFillToSvgElement(svgElement, previewFill);
+        }
       }
     } else if (svgOutput && svgOutput.startsWith("Error:")) {
       previewElement.innerText = svgOutput;
@@ -157,6 +178,7 @@ export function setupPreviewListeners() {
   const typstInput = document.getElementById("typstInput");
   const fontSizeInput = document.getElementById("fontSize");
   const fillColorInput = document.getElementById("fillColor");
+  const fillColorEnabled = document.getElementById("fillColorEnabled");
 
   if (typstInput) {
     typstInput.addEventListener("input", () => {
@@ -176,6 +198,18 @@ export function setupPreviewListeners() {
     fillColorInput.addEventListener("input", () => {
       const fillColor = getFillColor();
       storeValue("typstFillColor", fillColor);
+      updatePreview();
+    });
+  }
+
+  if (fillColorEnabled) {
+    fillColorEnabled.addEventListener("change", () => {
+      const fillColor = getFillColor();
+      const colorInput = document.getElementById("fillColor");
+      if (colorInput) {
+        colorInput.disabled = !fillColorEnabled.checked;
+      }
+      storeValue("typstFillColor", fillColor || "disabled");
       updatePreview();
     });
   }

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -71,10 +71,15 @@ function calculateActualBounds(svgElement) {
 /**
  * Applies fill color to all elements in an SVG string
  * @param {string} svg - SVG content as string
- * @param {string} fillColor - The fill color to apply
+ * @param {string|null} fillColor - The fill color to apply, or null to skip
  * @returns {string} Modified SVG with fill color applied
  */
 export function applyFillColorToSvg(svg, fillColor) {
+  if (fillColor === null) {
+    // user wants to use no color at all, or the color from Typst code
+    return svg;
+  }
+
   try {
     const parser = new DOMParser();
     const doc = parser.parseFromString(svg, "image/svg+xml");

--- a/web/styles.css
+++ b/web/styles.css
@@ -97,6 +97,30 @@ body {
     cursor: pointer;
 }
 
+.fill-color-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.fill-color-group label {
+    display: flex;
+    align-items: center;
+    margin: 0;
+}
+
+.fill-color-group input[type="checkbox"] {
+    margin-right: 4px;
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+}
+
+.fill-color-group input[type="color"]:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 textarea {
     width: 100%;
     height: 180px;


### PR DESCRIPTION
Users may want to not use any fill color defined in the UI, such that they can define their custom color in the Typst code itself, e.g.

```typst
#set text(fill: rgb("#2596be"))
This text will be in another color. $a+b$
```
