### PR TITLE
Be more aggressive in coloring SVG

### DIFF
--- a/web/src/svg.ts
+++ b/web/src/svg.ts
@@ -47,7 +47,6 @@ export function parseAndApplySize(svg: string):
 
 /**
  * Applies fill color to all elements in an SVG element.
- *
  */
 export function applyFillColor(svg: SVGElement, fillColor: string) {
   const elements = svg.querySelectorAll("*");


### PR DESCRIPTION
Something like `$sqrt(4x^2)$` was not colored correctly beforehand (the stroke above `4x^2` was still black, not the custom color). We fix this by being more aggressive in the way we color the SVG.