### PR TITLE
Fix wrong task pane url

### DIFF
--- a/web/manifest.prod.xml
+++ b/web/manifest.prod.xml
@@ -107,7 +107,7 @@
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://github.com/Splines/typst-powerpoint" />
-        <bt:Url id="Taskpane.Url" DefaultValue="https://splines.github.io/typst-powerpoint/index.html" />
+        <bt:Url id="Taskpane.Url" DefaultValue="https://splines.github.io/typst-powerpoint/powerpoint.html" />
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with Typst!" />

--- a/web/manifest.xml
+++ b/web/manifest.xml
@@ -107,7 +107,7 @@
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://github.com/Splines/typst-powerpoint" />
-        <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3155/index.html" />
+        <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3155/powerpoint.html" />
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with Typst!" />


### PR DESCRIPTION
The taskpane url pointed to `index.html` and not our new `powerpoint.html` file.